### PR TITLE
[CDD] Develop and button component #05

### DIFF
--- a/src/components/AnswerOption/AnswerOption.constants.ts
+++ b/src/components/AnswerOption/AnswerOption.constants.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_VARIANT = 'horizontal';
+export const DEFAULT_SIZE = 'medium';
+
+export const ICON_SIZES = {
+  small: '1.25rem',
+  medium: '2rem',
+  large: '2.5rem',
+};
+
+export const DESIGN_TOKENS = {
+  colors: {
+    backgroundDefault: '#272436',
+    //CORRECCIÓN: backgroundSelected añadido para tipado y estilos
+    backgroundSelected: '#2E2A40',
+    borderDefault: '#B23DEB',
+    borderDisabled: '#4F4F4F',
+    textDefault: '#FFFFFF',
+    //MEJORA: Token explícito para el color de texto deshabilitado
+    textDisabled: '#4F4F4F',
+    gradientStart: '#B23DEB',
+    gradientEnd: '#DE8FFF',
+  },
+  borders: {
+    radius: '1.25rem',
+    width: '0.125rem',
+  },
+};

--- a/src/components/AnswerOption/AnswerOption.docs.mdx
+++ b/src/components/AnswerOption/AnswerOption.docs.mdx
@@ -1,0 +1,108 @@
+import {
+  Meta,
+  Title,
+  Subtitle,
+  Description,
+  Primary,
+  Controls,
+  Canvas,
+  Stories,
+  Source,
+} from '@storybook/blocks';
+import * as AnswerOptionStories from './AnswerOption.stories';
+
+{/* 1. META: Links the documentation with the stories file (CSF) */}
+<Meta of={AnswerOptionStories} />
+
+{/* HEADING AND DESCRIPTION */}
+<Title />
+<Subtitle>Modular Component for Form Selections</Subtitle>
+
+{/* The component description is extracted from the JSDoc in the CSF file */}
+<Description of={AnswerOptionStories} />
+
+# `AnswerOption` Component
+
+The **`AnswerOption`** component is an abstraction designed to represent a selectable option (radio or checkbox) within a group of answers. It focuses on providing a large click area, clear visual feedback, and robust accessibility, decoupling the selection logic from the visual component.
+
+---
+
+## 🚀 Interactive Showcase
+
+Use the `Canvas` to view the primary story and the `Controls` to manipulate its properties in real time.
+
+<Canvas of={AnswerOptionStories.Default} />
+
+{/* 2. CONTROLS: Shows the automatically generated properties (props) table. */}
+## ⚙️ Properties (Props)
+
+The available properties for `AnswerOption` are detailed below. Their typing and description come from the TypeScript interface (`AnswerOption.types.ts`) and the `argTypes` in the stories file.
+
+<Controls of={AnswerOptionStories.Default} />
+
+---
+
+## 🎨 Variations and States
+
+Explore all predefined variations and states of the component to ensure its consistent use in different user interface contexts.
+
+{/* 3. STORIES: Displays all the stories defined in the AnswerOption.stories.tsx file */}
+<Stories />
+
+### Implementation Example (TSX Code)
+
+Example of how to integrate `AnswerOption` into a selection group, controlling the state of the chosen option.
+
+<Source
+  language="tsx"
+  code={`
+import React, { useState, useCallback } from 'react';
+import { AnswerOption } from './AnswerOption';
+import { Box } from '@mui/material';
+
+// Example data
+const questionOptions = [
+  { id: '1', value: 'opA', label: 'Option A: Default Selection' },
+  { id: '2', value: 'opB', label: 'Option B: Unselected State' },
+  { id: '3', value: 'opC', label: 'Option C: Disabled Option', disabled: true },
+];
+
+const QuizSelectionGroup = () => {
+  const [selectedValue, setSelectedValue] = useState('opA');
+
+  const handleChange = useCallback((newValue) => {
+    setSelectedValue(newValue);
+  }, []);
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '8px', padding: '16px' }}>
+      {questionOptions.map((option) => (
+        <AnswerOption
+          key={option.id}
+          label={option.label}
+          value={option.value}
+          // Determines the 'selected' state
+          selected={selectedValue === option.value}
+          // Handler function that updates the state
+          onChange={handleChange}
+          disabled={option.disabled}
+        />
+      ))}
+      <p>Selected: <b>{selectedValue}</b></p>
+    </Box>
+  );
+};
+
+export default QuizSelectionGroup;
+`}
+/>
+
+---
+
+## ♿ Accessibility (A11y)
+
+This component ensures accessibility (WAI-ARIA) by:
+
+1.  **Wrapping the content in a `<label>` tag:** This ensures that clicking anywhere on the component activates the option.
+2.  **Using a Hidden Input:** The actual "radio" or "checkbox" behavior is managed with a native (visually hidden) `<input>` so that assistive technologies (screen readers) recognize it and allow keyboard interaction.
+3.  **Communicating States:** ARIA attributes, such as `aria-checked` and `disabled`, are dynamically configured to communicate the exact state of the component to the user.

--- a/src/components/AnswerOption/AnswerOption.stories.tsx
+++ b/src/components/AnswerOption/AnswerOption.stories.tsx
@@ -1,0 +1,97 @@
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+
+import { AnswerOption } from './AnswerOption';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+    background: { default: '#1A1825' },
+    text: { primary: '#FFFFFF' },
+  },
+  typography: { fontFamily: "'Syne', sans-serif" },
+});
+
+const meta: Meta<typeof AnswerOption> = {
+  title: 'Components/AnswerOption',
+  component: AnswerOption,
+
+  decorators: [
+    (Story) => (
+      <ThemeProvider theme={darkTheme}>
+        <div
+          style={{
+            padding: '2rem',
+            display: 'flex',
+            //CORRECCIÓN: Alineación al principio (flex-start)
+            justifyContent: 'flex-start',
+          }}
+        >
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+  argTypes: {
+    onChange: { action: 'option selected' },
+    variant: {
+      control: 'radio',
+      options: ['horizontal', 'vertical'],
+    },
+    size: {
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+    },
+  },
+  args: {
+    //CORRECCIÓN: Usar función vacía para evitar el error 'no-console' del linter
+    onChange: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AnswerOption>;
+
+export const Default: Story = {
+  args: {
+    label: 'Female',
+    value: 'female',
+    selected: true,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    label: 'Female',
+    value: 'female',
+    selected: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Female',
+    value: 'disabled',
+    disabled: true,
+    selected: false,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    label: 'Female',
+    value: 'small',
+    size: 'small',
+    selected: true,
+  },
+};
+
+export const Large: Story = {
+  args: {
+    label: 'Female',
+    value: 'large',
+    size: 'large',
+    selected: true,
+  },
+};

--- a/src/components/AnswerOption/AnswerOption.styles.ts
+++ b/src/components/AnswerOption/AnswerOption.styles.ts
@@ -1,0 +1,139 @@
+import { styled } from '@mui/material/styles';
+
+import { DESIGN_TOKENS } from './AnswerOption.constants';
+
+import type { AnswerOptionProps } from './types/AnswerOption.types';
+
+const GRADIENT_CSS = `linear-gradient(90deg, ${DESIGN_TOKENS.colors.gradientStart} 0%, ${DESIGN_TOKENS.colors.gradientEnd} 100%)`;
+
+//FACTORIZACIÓN: SIZE_MAP movido desde AnswerOption.helpers.ts a estilos
+const SIZE_MAP = {
+  large: {
+    padding: '2.5rem 3rem',
+    fontSize: '1.75rem',
+    mobile: {
+      padding: '1.25rem 1.75rem',
+      fontSize: '1.25rem',
+      minWidth: '10rem',
+    },
+  },
+  medium: {
+    padding: '2rem 2.5rem',
+    fontSize: '1.5rem',
+    mobile: {
+      padding: '1rem 1.25rem',
+      fontSize: '1rem',
+      minWidth: '10rem',
+    },
+  },
+  small: {
+    padding: '1.5rem 2rem',
+    fontSize: '1.25rem',
+    mobile: {
+      padding: '0.75rem 1rem',
+      fontSize: '0.9rem',
+      minWidth: '8rem',
+    },
+  },
+};
+
+export const Container = styled('label', {
+  shouldForwardProp: (prop) =>
+    prop !== 'selected' && prop !== 'disabled' && prop !== 'variant' && prop !== 'size',
+})<Pick<AnswerOptionProps, 'selected' | 'disabled' | 'variant' | 'size'>>(
+  ({ theme, selected, disabled, variant, size = 'medium' }) => ({
+    display: 'flex',
+    flexDirection: variant === 'vertical' ? 'column' : 'row',
+    alignItems: 'center',
+    justifyContent: variant === 'vertical' ? 'center' : 'flex-start',
+    gap: theme.spacing(2),
+
+    width: 'fit-content',
+    minWidth: '15rem',
+    maxWidth: '30rem',
+    padding: SIZE_MAP[size].padding,
+
+    //Lógica de Responsividad (ajuste de padding y min-width en móvil)
+    [theme.breakpoints.down('sm')]: {
+      padding: SIZE_MAP[size].mobile.padding,
+      minWidth: SIZE_MAP[size].mobile.minWidth,
+    },
+
+    backgroundColor: DESIGN_TOKENS.colors.backgroundDefault,
+    borderRadius: DESIGN_TOKENS.borders.radius,
+    border: `${DESIGN_TOKENS.borders.width} dashed ${disabled ? DESIGN_TOKENS.colors.borderDisabled : DESIGN_TOKENS.colors.borderDefault}`,
+
+    boxSizing: 'border-box',
+    position: 'relative',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.9 : 1,
+    transition: 'all 0.2s ease-in-out',
+
+    ...(selected && {
+      backgroundColor: DESIGN_TOKENS.colors.backgroundSelected,
+      boxShadow: `0 0 10px 0 ${DESIGN_TOKENS.colors.gradientStart}AA, inset 0 0 2px 0 ${DESIGN_TOKENS.colors.gradientStart}50`,
+      borderColor: DESIGN_TOKENS.colors.borderDefault,
+    }),
+
+    WebkitUserSelect: 'none',
+    MozUserSelect: 'none',
+    msUserSelect: 'none',
+    userSelect: 'none',
+
+    '&:hover': {
+      backgroundColor: !disabled && DESIGN_TOKENS.colors.backgroundSelected,
+      borderColor: !disabled && DESIGN_TOKENS.colors.gradientEnd,
+    },
+  })
+);
+
+// CORRECCIÓN: Input visualmente oculto (Accesibilidad/Semántica)
+export const VisuallyHiddenInput = styled('input')({
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  width: '1px',
+});
+
+// Lógica de texto y tamaño responsive
+export const LabelText = styled('span')<{
+  selected?: boolean;
+  disabled?: boolean;
+  size: AnswerOptionProps['size'];
+}>(({ theme, selected, disabled, size = 'medium' }) => ({
+  fontFamily: "'Syne', sans-serif",
+  lineHeight: 1.2,
+  fontWeight: selected ? 700 : 500,
+
+  // Lógica de tamaño responsive
+  fontSize: SIZE_MAP[size].fontSize,
+  [theme.breakpoints.down('sm')]: {
+    fontSize: SIZE_MAP[size].mobile.fontSize,
+  },
+  //CORRECCIÓN: Color de texto disabled (#4F4F4F)
+  color: disabled ? DESIGN_TOKENS.colors.textDisabled : DESIGN_TOKENS.colors.textDefault,
+
+  ...(selected && {
+    background: GRADIENT_CSS,
+    WebkitBackgroundClip: 'text',
+    WebkitTextFillColor: 'transparent',
+    backgroundClip: 'text',
+    textFillColor: 'transparent',
+    WebkitFontSmoothing: 'antialiased',
+    MozOsxFontSmoothing: 'grayscale',
+  }),
+}));
+
+export const IconWrapper = styled('div')<{ size: string }>(({ size }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: size,
+  height: size,
+  flexShrink: 0,
+}));

--- a/src/components/AnswerOption/AnswerOption.test.tsx
+++ b/src/components/AnswerOption/AnswerOption.test.tsx
@@ -1,0 +1,100 @@
+import { useMediaQuery } from '@mui/material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { AnswerOption } from './AnswerOption';
+
+vi.mock('@mui/material', async () => {
+  const actual = await vi.importActual<typeof import('@mui/material')>('@mui/material');
+  return {
+    ...actual,
+    useMediaQuery: vi.fn(),
+  };
+});
+
+const mockedUseMediaQuery = useMediaQuery as unknown as {
+  mockReturnValue: (value: boolean) => void;
+};
+
+const renderWithTheme = (component: React.ReactNode) => {
+  const theme = createTheme();
+  return render(<ThemeProvider theme={theme}>{component}</ThemeProvider>);
+};
+
+describe('AnswerOption Component', () => {
+  const defaultProps = {
+    label: 'Test Option',
+    value: 'test',
+    selected: false,
+    onChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseMediaQuery.mockReturnValue(false);
+  });
+
+  it('renders label correctly', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} />);
+    expect(screen.getByText('Test Option')).toBeInTheDocument();
+  });
+
+  it('is accessible via radio role', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} />);
+    expect(screen.getByRole('radio')).toBeInTheDocument();
+  });
+
+  it('shows checked state correctly', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} selected={true} />);
+    expect(screen.getByRole('radio')).toBeChecked();
+  });
+
+  it('calls onChange when clicked', () => {
+    const handleChange = vi.fn();
+    renderWithTheme(<AnswerOption {...defaultProps} onChange={handleChange} />);
+    fireEvent.click(screen.getByText('Test Option'));
+    expect(handleChange).toHaveBeenCalledWith('test');
+  });
+
+  it('does not call onChange when disabled', () => {
+    const handleChange = vi.fn();
+    renderWithTheme(<AnswerOption {...defaultProps} disabled={true} onChange={handleChange} />);
+    fireEvent.click(screen.getByText('Test Option'));
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('radio')).toBeDisabled();
+  });
+
+  it('renders skeletons when isLoading is true', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} isLoading={true} />);
+    const skeletons = document.querySelectorAll('.MuiSkeleton-root');
+    expect(skeletons.length).toBeGreaterThan(0);
+    expect(screen.queryByText('Test Option')).not.toBeInTheDocument();
+  });
+
+  it('renders horizontal layout by default (desktop)', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} />);
+    const container = screen.getByTestId(`answer-option-container-${defaultProps.value}`);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders vertical layout when variant="vertical"', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} variant="vertical" />);
+    const container = screen.getByTestId(`answer-option-container-${defaultProps.value}`);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('adapts to vertical layout when on mobile (useMediaQuery is true)', () => {
+    mockedUseMediaQuery.mockReturnValue(true);
+    renderWithTheme(<AnswerOption {...defaultProps} variant="horizontal" />);
+    const container = screen.getByTestId(`answer-option-container-${defaultProps.value}`);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('applies the disabled text color when disabled', () => {
+    renderWithTheme(<AnswerOption {...defaultProps} disabled={true} />);
+    const labelElement = screen.getByText('Test Option');
+    expect(labelElement).toBeInTheDocument();
+  });
+});

--- a/src/components/AnswerOption/AnswerOption.tsx
+++ b/src/components/AnswerOption/AnswerOption.tsx
@@ -1,0 +1,73 @@
+import { useTheme, useMediaQuery, Skeleton } from '@mui/material';
+import React, { useId } from 'react';
+
+import { DEFAULT_VARIANT, DEFAULT_SIZE, ICON_SIZES } from './AnswerOption.constants';
+import { Container, VisuallyHiddenInput, LabelText, IconWrapper } from './AnswerOption.styles';
+import { CircleIcon } from './assets/icons/CircleIcon';
+
+import type { AnswerOptionProps } from './types/AnswerOption.types';
+
+export const AnswerOption: React.FC<AnswerOptionProps> = ({
+  label,
+  value,
+  selected,
+  onChange,
+  disabled = false,
+  variant: variantProp = DEFAULT_VARIANT,
+  size = DEFAULT_SIZE,
+  isLoading = false,
+  className,
+}) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const uniqueId = useId();
+  const inputId = `answer-input-${uniqueId}`;
+
+  const variant = isMobile ? 'vertical' : variantProp;
+
+  const iconSizeRem = ICON_SIZES[size];
+  const iconSizePx = parseFloat(iconSizeRem) * 16;
+
+  if (isLoading) {
+    // [C7] CORRECCIÓN: Se añade selected={false} para corregir el error de tipado en el estado isLoading
+    return (
+      <Container as="div" variant={variant} disabled={true} selected={false} size={size}>
+        <Skeleton variant="circular" width={iconSizeRem} height={iconSizeRem} />
+        <Skeleton variant="text" width="60%" height={32} />
+      </Container>
+    );
+  }
+
+  return (
+    <Container
+      selected={selected}
+      disabled={disabled}
+      variant={variant}
+      size={size}
+      className={className}
+      htmlFor={inputId}
+      data-testid={`answer-option-container-${value}`}
+    >
+      <VisuallyHiddenInput
+        id={inputId}
+        type="radio"
+        name="answer-option-group"
+        value={value}
+        checked={selected}
+        disabled={disabled}
+        onChange={() => !disabled && onChange(value)}
+        aria-label={label}
+        tabIndex={0}
+      />
+
+      <IconWrapper size={iconSizeRem}>
+        <CircleIcon size={iconSizePx} id={uniqueId} selected={selected} />
+      </IconWrapper>
+
+      <LabelText selected={selected} disabled={disabled} size={size}>
+        {label}
+      </LabelText>
+    </Container>
+  );
+};

--- a/src/components/AnswerOption/assets/icons/CheckIcon.tsx
+++ b/src/components/AnswerOption/assets/icons/CheckIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface CheckIconProps {
+  width: number;
+  height: number;
+  color?: string;
+}
+
+export const CheckIcon: React.FC<CheckIconProps> = ({ width, height, color = 'white' }) => (
+  <svg
+    width={width}
+    height={height}
+    viewBox="0 0 10 8"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M3.5734 7.14624C3.32699 7.14624 3.08059 7.05274 2.89249 6.86464L0.282154 4.25431C-0.0940512 3.8781 -0.0940512 3.26869 0.282154 2.89359C0.658358 2.51738 1.26667 2.51628 1.64287 2.89249L3.5734 4.82301L8.11425 0.282154C8.49046 -0.0940512 9.09877 -0.0940512 9.47498 0.282154C9.85118 0.658358 9.85118 1.26781 9.47498 1.64287L4.25997 6.85788C4.07187 7.04598 3.82546 7.14624 3.5734 7.14624Z"
+      fill={color}
+    />
+  </svg>
+);

--- a/src/components/AnswerOption/assets/icons/CircleIcon.tsx
+++ b/src/components/AnswerOption/assets/icons/CircleIcon.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+import { DESIGN_TOKENS } from '../../AnswerOption.constants';
+
+interface CircleIconProps {
+  size: number;
+  id: string;
+  selected: boolean;
+}
+
+export const CircleIcon: React.FC<CircleIconProps> = ({ size, id, selected }) => {
+  const gradientId = `answer-option-gradient-${id}`;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="0"
+          y1="0"
+          x2="64"
+          y2="64"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor={DESIGN_TOKENS.colors.gradientStart} />
+          <stop offset="1" stopColor={DESIGN_TOKENS.colors.gradientEnd} />
+        </linearGradient>
+      </defs>
+
+      <circle
+        cx="32"
+        cy="32"
+        r="30"
+        stroke={selected ? `url(#${gradientId})` : DESIGN_TOKENS.colors.borderDisabled}
+        strokeWidth="2"
+        fill={selected ? `url(#${gradientId})` : 'transparent'}
+      />
+
+      {selected && (
+        <path
+          d="M20 32 L28 40 L44 24"
+          stroke="white"
+          strokeWidth="4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+    </svg>
+  );
+};

--- a/src/components/AnswerOption/types/AnswerOption.types.ts
+++ b/src/components/AnswerOption/types/AnswerOption.types.ts
@@ -1,0 +1,12 @@
+//Corrección: Convención de nombres Props y Named Exports
+export interface AnswerOptionProps {
+  label: string;
+  value: string;
+  selected: boolean;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  variant?: 'horizontal' | 'vertical';
+  size?: 'small' | 'medium' | 'large';
+  isLoading?: boolean;
+  className?: string;
+}


### PR DESCRIPTION
<img width="1920" height="1077" alt="image" src="https://github.com/user-attachments/assets/cd340fae-b847-4629-8786-ba5acdbac50a" />

Create a reusable AnswerOption component for multiple-choice answers.

Accept label, value, selected state and onChange callback as props.
Use MUI’s Radio or Checkbox with custom styling via styled() for consistency.
Keep component logic minimal; isolate state logic in a hook if needed.
Provide TypeScript types and constants for sizes/variants.
Write unit tests ensuring correct selection and accessibility behavior.
Add Storybook stories showcasing selected/unselected and disabled states.
Document usage and examples in an MDX file.