### PR TITLE
feature/leetcode-198

### DIFF
--- a/src/component-catalog/Pagination/Pagination.constants.tsx
+++ b/src/component-catalog/Pagination/Pagination.constants.tsx
@@ -2,28 +2,53 @@ export const PAGINATION_TEST_ID = 'pagination-component';
 export const PREV_BUTTON_TEXT = 'Previous';
 export const NEXT_BUTTON_TEXT = 'Next';
 
+export const DEFAULT_PAGE_COUNT = 3;
+export const DEFAULT_ROWS_PER_PAGE_OPTIONS = [10, 20, 50];
+
 export const PrevIcon = () => (
   <>
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="1rem"
+      height="1rem"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
       <path
         d="M10 4L6 8L10 12"
-        stroke="#0A0A0A"
+        stroke="currentColor"
         strokeWidth="1.33333"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
     </svg>
-    <span className="button-text">{PREV_BUTTON_TEXT}</span>
+    {}
+    <span className="button-text" aria-hidden="true">
+      {PREV_BUTTON_TEXT}
+    </span>
   </>
 );
 
 export const NextIcon = () => (
   <>
-    <span className="button-text">{NEXT_BUTTON_TEXT}</span>
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    {}
+    <span className="button-text" aria-hidden="true">
+      {NEXT_BUTTON_TEXT}
+    </span>
+    <svg
+      width="1rem"
+      height="1rem"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
       <path
         d="M6 4L10 8L6 12"
-        stroke="#0A0A0A"
+        stroke="currentColor"
         strokeWidth="1.33333"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/component-catalog/Pagination/Pagination.constants.tsx
+++ b/src/component-catalog/Pagination/Pagination.constants.tsx
@@ -1,0 +1,33 @@
+export const PAGINATION_TEST_ID = 'pagination-component';
+export const PREV_BUTTON_TEXT = 'Previous';
+export const NEXT_BUTTON_TEXT = 'Next';
+
+export const PrevIcon = () => (
+  <>
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10 4L6 8L10 12"
+        stroke="#0A0A0A"
+        strokeWidth="1.33333"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+    <span className="button-text">{PREV_BUTTON_TEXT}</span>
+  </>
+);
+
+export const NextIcon = () => (
+  <>
+    <span className="button-text">{NEXT_BUTTON_TEXT}</span>
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M6 4L10 8L6 12"
+        stroke="#0A0A0A"
+        strokeWidth="1.33333"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  </>
+);

--- a/src/component-catalog/Pagination/Pagination.constants.tsx
+++ b/src/component-catalog/Pagination/Pagination.constants.tsx
@@ -24,7 +24,6 @@ export const PrevIcon = () => (
         strokeLinejoin="round"
       />
     </svg>
-    {}
     <span className="button-text" aria-hidden="true">
       {PREV_BUTTON_TEXT}
     </span>
@@ -33,7 +32,6 @@ export const PrevIcon = () => (
 
 export const NextIcon = () => (
   <>
-    {}
     <span className="button-text" aria-hidden="true">
       {NEXT_BUTTON_TEXT}
     </span>

--- a/src/component-catalog/Pagination/Pagination.docs.mdx
+++ b/src/component-catalog/Pagination/Pagination.docs.mdx
@@ -1,4 +1,4 @@
-import { Meta, Canvas, Story, Controls } from '@storybook/blocks';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
 import * as PaginationStories from './Pagination.stories';
 
 <Meta of={PaginationStories} />
@@ -8,7 +8,7 @@ import * as PaginationStories from './Pagination.stories';
 A responsive, accessible pagination component built on top of Material UI's `Pagination`. This component strictly follows the design system rules and Component-Driven architecture guidelines.
 
 **Key Features:**
-- **Responsive Design:** Gracefully collapses into `36x36px` icon-only buttons on mobile breakpoints (`md`, `< 768px`) to prevent layout overflows and optimize touch targets.
+- **Responsive Design:** Gracefully collapses into `44x44px` icon-only buttons on mobile breakpoints (`md`, `< 768px`) to prevent layout overflows and optimize touch targets for accessibility.
 - **Custom Iconography:** Implements custom SVG arrow components matching exact Figma specifications (`1.33333px` stroke width).
 - **Accessibility (a11y):** Utilizes `aria-hidden` attributes on SVG elements and hidden text nodes to prevent screen reader duplication, relying purely on MUI's robust native `aria-labels`.
 - **Theme Integration:** Dynamically inherits text colors via `currentColor`, ensuring seamless adaptation to light/dark modes without hardcoded hex values.
@@ -20,6 +20,7 @@ import Pagination from './Pagination';
 
 export const Example = () => {
   return (
-    <Pagination count="{5}" onChange="{(event,"> console.log('Current page:', page)} />
+    <Pagination count={5} onChange="{(event,"> console.log('Current page:', page)} 
+    />
   );
 };

--- a/src/component-catalog/Pagination/Pagination.docs.mdx
+++ b/src/component-catalog/Pagination/Pagination.docs.mdx
@@ -1,0 +1,15 @@
+# Pagination
+
+A responsive pagination component built on top of Material UI's `Pagination`. It follows the design system rules, collapsing into icon-only buttons on mobile breakpoints.
+
+## Usage
+
+```tsx
+import { Pagination } from './Pagination';
+
+export const Example = () => {
+  return (
+    <Pagination count="{5}" onChange="{(e,"> console.log('Current page:', page)} 
+    />
+  );
+};

--- a/src/component-catalog/Pagination/Pagination.docs.mdx
+++ b/src/component-catalog/Pagination/Pagination.docs.mdx
@@ -1,6 +1,17 @@
+import { Meta, Canvas, Story, Controls } from '@storybook/blocks';
+import * as PaginationStories from './Pagination.stories';
+
+<Meta of={PaginationStories} />
+
 # Pagination
 
-A responsive pagination component built on top of Material UI's `Pagination`. It follows the design system rules, collapsing into icon-only buttons on mobile breakpoints.
+A responsive, accessible pagination component built on top of Material UI's `Pagination`. This component strictly follows the design system rules and Component-Driven architecture guidelines.
+
+**Key Features:**
+- **Responsive Design:** Gracefully collapses into `36x36px` icon-only buttons on mobile breakpoints (`md`, `< 768px`) to prevent layout overflows and optimize touch targets.
+- **Custom Iconography:** Implements custom SVG arrow components matching exact Figma specifications (`1.33333px` stroke width).
+- **Accessibility (a11y):** Utilizes `aria-hidden` attributes on SVG elements and hidden text nodes to prevent screen reader duplication, relying purely on MUI's robust native `aria-labels`.
+- **Theme Integration:** Dynamically inherits text colors via `currentColor`, ensuring seamless adaptation to light/dark modes without hardcoded hex values.
 
 ## Usage
 
@@ -9,7 +20,7 @@ import { Pagination } from './Pagination';
 
 export const Example = () => {
   return (
-    <Pagination count="{5}" onChange="{(e,"> console.log('Current page:', page)} 
+    <Pagination count="{5}" onChange="{(event,"> console.log('Current page:', page)}
     />
   );
 };

--- a/src/component-catalog/Pagination/Pagination.docs.mdx
+++ b/src/component-catalog/Pagination/Pagination.docs.mdx
@@ -16,11 +16,10 @@ A responsive, accessible pagination component built on top of Material UI's `Pag
 ## Usage
 
 ```tsx
-import { Pagination } from './Pagination';
+import Pagination from './Pagination';
 
 export const Example = () => {
   return (
-    <Pagination count="{5}" onChange="{(event,"> console.log('Current page:', page)}
-    />
+    <Pagination count="{5}" onChange="{(event,"> console.log('Current page:', page)} />
   );
 };

--- a/src/component-catalog/Pagination/Pagination.stories.tsx
+++ b/src/component-catalog/Pagination/Pagination.stories.tsx
@@ -1,6 +1,6 @@
-import Pagination from './Pagination';
-
 import type { Meta, StoryObj } from '@storybook/react';
+import type { SelectChangeEvent } from '@mui/material';
+import Pagination from './Pagination';
 
 const meta: Meta<typeof Pagination> = {
   title: 'component-catalog/Pagination',
@@ -14,25 +14,12 @@ const meta: Meta<typeof Pagination> = {
     onChange: { action: 'changed', description: 'Callback fired when the page is changed.' },
     showFirstButton: { control: 'boolean', description: 'If true, show the first-page button.' },
     showLastButton: { control: 'boolean', description: 'If true, show the last-page button.' },
-    siblingCount: {
-      control: 'number',
-      description: 'Number of always visible pages before and after the current page.',
-    },
-    boundaryCount: {
-      control: 'number',
-      description: 'Number of always visible pages at the beginning and end.',
-    },
+    siblingCount: { control: 'number', description: 'Number of always visible pages before and after the current page.' },
+    boundaryCount: { control: 'number', description: 'Number of always visible pages at the beginning and end.' },
     disabled: { control: 'boolean', description: 'If true, the component is disabled.' },
-    size: {
-      control: 'radio',
-      options: ['small', 'medium', 'large'],
-      description: 'The size of the component.',
-    },
+    size: { control: 'radio', options: ['small', 'medium', 'large'], description: 'The size of the component.' },
     rowsPerPage: { control: 'number', description: 'Current number of rows per page.' },
-    onRowsPerPageChange: {
-      action: 'rowsPerPageChanged',
-      description: 'Callback fired when the rows per page value changes.',
-    },
+    onRowsPerPageChange: { action: 'rowsPerPageChanged', description: 'Callback fired when the rows per page value changes.' },
   },
 };
 
@@ -66,6 +53,8 @@ export const WithRowsPerPage: Story = {
     count: 50,
     rowsPerPage: 10,
     rowsPerPageOptions: [10, 20, 50],
+    onRowsPerPageChange: (event: SelectChangeEvent<number>) => 
+      console.log('Rows per page:', event.target.value),
   },
 };
 

--- a/src/component-catalog/Pagination/Pagination.stories.tsx
+++ b/src/component-catalog/Pagination/Pagination.stories.tsx
@@ -1,6 +1,6 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import type { SelectChangeEvent } from '@mui/material';
 import Pagination from './Pagination';
+
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Pagination> = {
   title: 'component-catalog/Pagination',
@@ -14,12 +14,25 @@ const meta: Meta<typeof Pagination> = {
     onChange: { action: 'changed', description: 'Callback fired when the page is changed.' },
     showFirstButton: { control: 'boolean', description: 'If true, show the first-page button.' },
     showLastButton: { control: 'boolean', description: 'If true, show the last-page button.' },
-    siblingCount: { control: 'number', description: 'Number of always visible pages before and after the current page.' },
-    boundaryCount: { control: 'number', description: 'Number of always visible pages at the beginning and end.' },
+    siblingCount: {
+      control: 'number',
+      description: 'Number of always visible pages before and after the current page.',
+    },
+    boundaryCount: {
+      control: 'number',
+      description: 'Number of always visible pages at the beginning and end.',
+    },
     disabled: { control: 'boolean', description: 'If true, the component is disabled.' },
-    size: { control: 'radio', options: ['small', 'medium', 'large'], description: 'The size of the component.' },
+    size: {
+      control: 'radio',
+      options: ['small', 'medium', 'large'],
+      description: 'The size of the component.',
+    },
     rowsPerPage: { control: 'number', description: 'Current number of rows per page.' },
-    onRowsPerPageChange: { action: 'rowsPerPageChanged', description: 'Callback fired when the rows per page value changes.' },
+    onRowsPerPageChange: {
+      action: 'rowsPerPageChanged',
+      description: 'Callback fired when the rows per page value changes.',
+    },
   },
 };
 
@@ -53,8 +66,7 @@ export const WithRowsPerPage: Story = {
     count: 50,
     rowsPerPage: 10,
     rowsPerPageOptions: [10, 20, 50],
-    onRowsPerPageChange: (event: SelectChangeEvent<number>) => 
-      console.log('Rows per page:', event.target.value),
+    onRowsPerPageChange: () => {},
   },
 };
 

--- a/src/component-catalog/Pagination/Pagination.stories.tsx
+++ b/src/component-catalog/Pagination/Pagination.stories.tsx
@@ -1,16 +1,34 @@
-import { Pagination } from './Pagination';
+import Pagination from './Pagination';
 
+import type { PaginationProps } from './Pagination.types';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Pagination> = {
   title: 'component-catalog/Pagination',
   component: Pagination,
   parameters: {
-    layout: 'padded',
+    layout: 'centered',
   },
   argTypes: {
-    count: { control: 'number' },
-    page: { control: 'number' },
+    count: { control: 'number', description: 'Total number of pages.' },
+    page: { control: 'number', description: 'Current active page.' },
+    onChange: { action: 'changed', description: 'Callback fired when the page is changed.' },
+    showFirstButton: { control: 'boolean', description: 'If true, show the first-page button.' },
+    showLastButton: { control: 'boolean', description: 'If true, show the last-page button.' },
+    siblingCount: {
+      control: 'number',
+      description: 'Number of always visible pages before and after the current page.',
+    },
+    boundaryCount: {
+      control: 'number',
+      description: 'Number of always visible pages at the beginning and end.',
+    },
+    disabled: { control: 'boolean', description: 'If true, the component is disabled.' },
+    size: {
+      control: 'radio',
+      options: ['small', 'medium', 'large'],
+      description: 'The size of the component.',
+    },
   },
 };
 
@@ -30,9 +48,50 @@ export const ManyPages: Story = {
   },
 };
 
+export const WithFirstLastButtons: Story = {
+  args: {
+    count: 10,
+    page: 5,
+    showFirstButton: true,
+    showLastButton: true,
+  },
+};
+
+export const WithRowsPerPage: Story = {
+  render: (args: PaginationProps) => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '16px',
+        fontFamily: "'Inter', sans-serif",
+      }}
+    >
+      <span style={{ fontSize: '14px', color: '#4A5565' }}>Rows per page:</span>
+      <select style={{ padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }}>
+        <option value="10">10</option>
+        <option value="20">20</option>
+        <option value="50">50</option>
+      </select>
+      <Pagination {...args} />
+    </div>
+  ),
+  args: {
+    count: 5,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    count: 5,
+    disabled: true,
+  },
+};
+
 export const MobileView: Story = {
   args: {
-    count: 3,
+    count: 10,
+    siblingCount: 0,
   },
   parameters: {
     viewport: {

--- a/src/component-catalog/Pagination/Pagination.stories.tsx
+++ b/src/component-catalog/Pagination/Pagination.stories.tsx
@@ -1,6 +1,5 @@
 import Pagination from './Pagination';
 
-import type { PaginationProps } from './Pagination.types';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Pagination> = {
@@ -28,6 +27,11 @@ const meta: Meta<typeof Pagination> = {
       control: 'radio',
       options: ['small', 'medium', 'large'],
       description: 'The size of the component.',
+    },
+    rowsPerPage: { control: 'number', description: 'Current number of rows per page.' },
+    onRowsPerPageChange: {
+      action: 'rowsPerPageChanged',
+      description: 'Callback fired when the rows per page value changes.',
     },
   },
 };
@@ -58,26 +62,10 @@ export const WithFirstLastButtons: Story = {
 };
 
 export const WithRowsPerPage: Story = {
-  render: (args: PaginationProps) => (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '16px',
-        fontFamily: "'Inter', sans-serif",
-      }}
-    >
-      <span style={{ fontSize: '14px', color: '#4A5565' }}>Rows per page:</span>
-      <select style={{ padding: '4px 8px', borderRadius: '4px', border: '1px solid #ccc' }}>
-        <option value="10">10</option>
-        <option value="20">20</option>
-        <option value="50">50</option>
-      </select>
-      <Pagination {...args} />
-    </div>
-  ),
   args: {
-    count: 5,
+    count: 50,
+    rowsPerPage: 10,
+    rowsPerPageOptions: [10, 20, 50],
   },
 };
 
@@ -88,10 +76,18 @@ export const Disabled: Story = {
   },
 };
 
+export const WithCustomStyling: Story = {
+  args: {
+    count: 5,
+    color: 'secondary',
+    variant: 'outlined',
+    shape: 'rounded',
+  },
+};
+
 export const MobileView: Story = {
   args: {
     count: 10,
-    siblingCount: 0,
   },
   parameters: {
     viewport: {

--- a/src/component-catalog/Pagination/Pagination.stories.tsx
+++ b/src/component-catalog/Pagination/Pagination.stories.tsx
@@ -1,0 +1,42 @@
+import { Pagination } from './Pagination';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'component-catalog/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    count: { control: 'number' },
+    page: { control: 'number' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+export const Default: Story = {
+  args: {
+    count: 3,
+  },
+};
+
+export const ManyPages: Story = {
+  args: {
+    count: 10,
+    page: 1,
+  },
+};
+
+export const MobileView: Story = {
+  args: {
+    count: 3,
+  },
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile1',
+    },
+  },
+};

--- a/src/component-catalog/Pagination/Pagination.styles.ts
+++ b/src/component-catalog/Pagination/Pagination.styles.ts
@@ -1,0 +1,60 @@
+import { styled, Pagination, PaginationItem, Box } from '@mui/material';
+
+export const PaginationContainer = styled(Box)(({ theme }) => ({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  maxWidth: '1216px',
+  height: '86px',
+  background: '#FFFFFF',
+  border: '1px solid rgba(0, 0, 0, 0.1)',
+  borderRadius: '14px',
+  boxSizing: 'border-box',
+  padding: theme.spacing(0, 2),
+}));
+
+export const StyledPagination = styled(Pagination)({
+  '& .MuiPagination-ul': {
+    gap: '4px',
+    flexWrap: 'nowrap',
+  },
+});
+
+export const StyledPaginationItem = styled(PaginationItem)(({ theme }) => ({
+  height: '36px',
+  minWidth: '36px',
+  fontFamily: "'Inter', sans-serif",
+  fontWeight: 500,
+  fontSize: '14px',
+  color: '#0A0A0A',
+  borderRadius: '8px',
+  padding: '0 12px',
+  margin: 0,
+
+  '&.Mui-selected': {
+    backgroundColor: '#FFFFFF',
+    border: '1px solid rgba(0, 0, 0, 0.1)',
+    '&:hover': {
+      backgroundColor: 'rgba(0, 0, 0, 0.04)',
+    },
+  },
+
+  '&.MuiPaginationItem-previousNext': {
+    border: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    '& .button-text': {
+      display: 'inline',
+    },
+    [theme.breakpoints.down('md')]: {
+      padding: 0,
+      minWidth: '36px',
+      justifyContent: 'center',
+      '& .button-text': {
+        display: 'none',
+      },
+    },
+  },
+}));

--- a/src/component-catalog/Pagination/Pagination.styles.ts
+++ b/src/component-catalog/Pagination/Pagination.styles.ts
@@ -1,16 +1,11 @@
 import { styled, Pagination, PaginationItem, Box } from '@mui/material';
 
-export const PaginationContainer = styled(Box)(({ theme }) => ({
+export const PaginationContainer = styled(Box)({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
-  backgroundColor: theme.palette.background.paper,
-  border: `1px solid ${theme.palette.divider}`,
-  borderRadius: theme.shape.borderRadius,
-  boxSizing: 'border-box',
-  padding: theme.spacing(2, 3),
-}));
+});
 
 export const StyledPagination = styled(Pagination)(({ theme }) => ({
   '& .MuiPagination-ul': {
@@ -20,8 +15,8 @@ export const StyledPagination = styled(Pagination)(({ theme }) => ({
 }));
 
 export const StyledPaginationItem = styled(PaginationItem)(({ theme }) => ({
-  height: '36px',
-  minWidth: '36px',
+  height: theme.spacing(4.5),
+  minWidth: theme.spacing(4.5),
   fontFamily: theme.typography.fontFamily,
   fontWeight: theme.typography.fontWeightMedium,
   fontSize: '0.875rem',
@@ -48,8 +43,8 @@ export const StyledPaginationItem = styled(PaginationItem)(({ theme }) => ({
     },
     [theme.breakpoints.down('md')]: {
       padding: 0,
-      minWidth: '44px',
-      height: '44px',
+      minWidth: theme.spacing(5.5),
+      height: theme.spacing(5.5),
       justifyContent: 'center',
       '& .button-text': {
         display: 'none',

--- a/src/component-catalog/Pagination/Pagination.styles.ts
+++ b/src/component-catalog/Pagination/Pagination.styles.ts
@@ -5,38 +5,36 @@ export const PaginationContainer = styled(Box)(({ theme }) => ({
   alignItems: 'center',
   justifyContent: 'center',
   width: '100%',
-  maxWidth: '1216px',
-  height: '86px',
-  background: '#FFFFFF',
-  border: '1px solid rgba(0, 0, 0, 0.1)',
-  borderRadius: '14px',
+  backgroundColor: theme.palette.background.paper,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.shape.borderRadius,
   boxSizing: 'border-box',
-  padding: theme.spacing(0, 2),
+  padding: theme.spacing(2, 3),
 }));
 
-export const StyledPagination = styled(Pagination)({
+export const StyledPagination = styled(Pagination)(({ theme }) => ({
   '& .MuiPagination-ul': {
-    gap: '4px',
-    flexWrap: 'nowrap',
+    gap: theme.spacing(0.5),
+    flexWrap: 'wrap',
   },
-});
+}));
 
 export const StyledPaginationItem = styled(PaginationItem)(({ theme }) => ({
   height: '36px',
   minWidth: '36px',
-  fontFamily: "'Inter', sans-serif",
-  fontWeight: 500,
-  fontSize: '14px',
-  color: '#0A0A0A',
-  borderRadius: '8px',
-  padding: '0 12px',
+  fontFamily: theme.typography.fontFamily,
+  fontWeight: theme.typography.fontWeightMedium,
+  fontSize: '0.875rem',
+  color: theme.palette.text.primary,
+  borderRadius: theme.shape.borderRadius,
+  padding: theme.spacing(0, 1.5),
   margin: 0,
 
   '&.Mui-selected': {
-    backgroundColor: '#FFFFFF',
-    border: '1px solid rgba(0, 0, 0, 0.1)',
+    backgroundColor: theme.palette.background.paper,
+    border: `1px solid ${theme.palette.divider}`,
     '&:hover': {
-      backgroundColor: 'rgba(0, 0, 0, 0.04)',
+      backgroundColor: theme.palette.action.hover,
     },
   },
 
@@ -44,13 +42,14 @@ export const StyledPaginationItem = styled(PaginationItem)(({ theme }) => ({
     border: 'none',
     display: 'flex',
     alignItems: 'center',
-    gap: '8px',
+    gap: theme.spacing(1),
     '& .button-text': {
       display: 'inline',
     },
     [theme.breakpoints.down('md')]: {
       padding: 0,
-      minWidth: '36px',
+      minWidth: '44px',
+      height: '44px',
       justifyContent: 'center',
       '& .button-text': {
         display: 'none',

--- a/src/component-catalog/Pagination/Pagination.test.tsx
+++ b/src/component-catalog/Pagination/Pagination.test.tsx
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Pagination from './Pagination';
 import { PAGINATION_TEST_ID, PREV_BUTTON_TEXT, NEXT_BUTTON_TEXT } from './Pagination.constants';
 
-// Safely mock useMediaQuery without breaking the rest of @mui/material components
 vi.mock('@mui/material', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@mui/material')>();
   return {
@@ -17,7 +16,6 @@ vi.mock('@mui/material', async (importOriginal) => {
 describe('Pagination Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default to desktop view (isMobile = false)
     vi.mocked(useMediaQuery).mockReturnValue(false);
   });
 
@@ -119,14 +117,10 @@ describe('Pagination Component', () => {
   });
 
   it('reduces siblingCount on mobile viewport using useMediaQuery', () => {
-    // Simulate mobile viewport where useMediaQuery(down('sm')) returns true
     vi.mocked(useMediaQuery).mockReturnValue(true);
 
-    // With siblingCount dynamically reduced, fewer sibling pages should render
     render(<Pagination count={10} page={5} />);
 
-    // Page 5 is active. If siblingCount is reduced to 0/1 on mobile,
-    // distant siblings like 3 or 7 shouldn't be rendered.
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.queryByText('3')).not.toBeInTheDocument();
     expect(screen.queryByText('7')).not.toBeInTheDocument();

--- a/src/component-catalog/Pagination/Pagination.test.tsx
+++ b/src/component-catalog/Pagination/Pagination.test.tsx
@@ -1,10 +1,26 @@
+import { useMediaQuery } from '@mui/material';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import Pagination from './Pagination';
 import { PAGINATION_TEST_ID, PREV_BUTTON_TEXT, NEXT_BUTTON_TEXT } from './Pagination.constants';
 
+// Safely mock useMediaQuery without breaking the rest of @mui/material components
+vi.mock('@mui/material', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mui/material')>();
+  return {
+    ...actual,
+    useMediaQuery: vi.fn(),
+  };
+});
+
 describe('Pagination Component', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default to desktop view (isMobile = false)
+    vi.mocked(useMediaQuery).mockReturnValue(false);
+  });
+
   it('renders the pagination container correctly', () => {
     render(<Pagination count={5} />);
     const container = screen.getByTestId(PAGINATION_TEST_ID);
@@ -47,5 +63,72 @@ describe('Pagination Component', () => {
 
     expect(prevButton).toContainElement(prevText);
     expect(nextButton).toContainElement(nextText);
+  });
+
+  it('calls onChange with page 1 when the first button is clicked', () => {
+    const handleChange = vi.fn();
+    render(<Pagination count={5} page={3} showFirstButton onChange={handleChange} />);
+
+    const firstButton = screen.getByLabelText(/go to first page/i);
+    fireEvent.click(firstButton);
+
+    expect(handleChange).toHaveBeenCalledWith(expect.anything(), 1);
+  });
+
+  it('calls onChange with the last page when the last button is clicked', () => {
+    const handleChange = vi.fn();
+    render(<Pagination count={5} page={3} showLastButton onChange={handleChange} />);
+
+    const lastButton = screen.getByLabelText(/go to last page/i);
+    fireEvent.click(lastButton);
+
+    expect(handleChange).toHaveBeenCalledWith(expect.anything(), 5);
+  });
+
+  it('calls onRowsPerPageChange when rows per page selection changes', () => {
+    const handleRowsPerPageChange = vi.fn();
+    render(
+      <Pagination
+        count={50}
+        rowsPerPage={10}
+        rowsPerPageOptions={[10, 20, 50]}
+        onRowsPerPageChange={handleRowsPerPageChange}
+      />
+    );
+
+    const select = screen.getByRole('combobox');
+    fireEvent.mouseDown(select);
+
+    const option20 = screen.getByRole('option', { name: '20' });
+    fireEvent.click(option20);
+
+    expect(handleRowsPerPageChange).toHaveBeenCalledTimes(1);
+    expect(handleRowsPerPageChange).toHaveBeenCalledWith(expect.anything(), expect.anything());
+  });
+
+  it('disables all buttons when disabled prop is true', () => {
+    const handleChange = vi.fn();
+    render(<Pagination count={3} disabled onChange={handleChange} />);
+
+    const prevButton = screen.getByLabelText(/go to previous page/i);
+    expect(prevButton).toBeDisabled();
+
+    const pageTwoButton = screen.getByText('2');
+    fireEvent.click(pageTwoButton);
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('reduces siblingCount on mobile viewport using useMediaQuery', () => {
+    // Simulate mobile viewport where useMediaQuery(down('sm')) returns true
+    vi.mocked(useMediaQuery).mockReturnValue(true);
+
+    // With siblingCount dynamically reduced, fewer sibling pages should render
+    render(<Pagination count={10} page={5} />);
+
+    // Page 5 is active. If siblingCount is reduced to 0/1 on mobile,
+    // distant siblings like 3 or 7 shouldn't be rendered.
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.queryByText('3')).not.toBeInTheDocument();
+    expect(screen.queryByText('7')).not.toBeInTheDocument();
   });
 });

--- a/src/component-catalog/Pagination/Pagination.test.tsx
+++ b/src/component-catalog/Pagination/Pagination.test.tsx
@@ -104,8 +104,7 @@ describe('Pagination Component', () => {
     expect(handleRowsPerPageChange).toHaveBeenCalledWith(
       expect.objectContaining({
         target: expect.objectContaining({ value: 20 }),
-      }),
-      expect.anything()
+      })
     );
   });
 
@@ -127,7 +126,7 @@ describe('Pagination Component', () => {
     render(<Pagination count={10} page={5} />);
 
     expect(screen.getByText('5')).toBeInTheDocument();
-    expect(screen.queryByText('3')).not.toBeInTheDocument();
-    expect(screen.queryByText('7')).not.toBeInTheDocument();
+    expect(screen.queryByText('4')).not.toBeInTheDocument();
+    expect(screen.queryByText('6')).not.toBeInTheDocument();
   });
 });

--- a/src/component-catalog/Pagination/Pagination.test.tsx
+++ b/src/component-catalog/Pagination/Pagination.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
-import { Pagination } from './Pagination';
-import { PAGINATION_TEST_ID } from './Pagination.constants';
+import Pagination from './Pagination';
+import { PAGINATION_TEST_ID, PREV_BUTTON_TEXT, NEXT_BUTTON_TEXT } from './Pagination.constants';
 
 describe('Pagination Component', () => {
   it('renders the pagination container correctly', () => {
@@ -11,26 +11,41 @@ describe('Pagination Component', () => {
     expect(container).toBeInTheDocument();
   });
 
-  it('renders the correct number of pages', () => {
+  it('renders the specific page numbers and navigation buttons', () => {
     render(<Pagination count={3} />);
-    // Expect pages 1, 2, 3 plus Prev and Next items
-    const items = screen.getAllByRole('button');
-    expect(items).toHaveLength(5);
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+
+    expect(screen.getByLabelText(/go to previous page/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/go to next page/i)).toBeInTheDocument();
   });
 
-  it('triggers onChange event when a page is clicked', () => {
+  it('triggers onChange event with the correct page number when a page is clicked', () => {
     const handleChange = vi.fn();
     render(<Pagination count={3} onChange={handleChange} />);
 
     const pageTwoButton = screen.getByText('2');
-    pageTwoButton.click();
+    fireEvent.click(pageTwoButton);
 
     expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(expect.anything(), 2);
   });
 
-  it('renders custom previous and next texts', () => {
+  it('renders custom previous and next texts associated with the correct buttons', () => {
     render(<Pagination count={3} />);
-    expect(screen.getByText('Previous')).toBeInTheDocument();
-    expect(screen.getByText('Next')).toBeInTheDocument();
+
+    const prevText = screen.getByText(PREV_BUTTON_TEXT);
+    const nextText = screen.getByText(NEXT_BUTTON_TEXT);
+
+    expect(prevText).toBeInTheDocument();
+    expect(nextText).toBeInTheDocument();
+
+    const prevButton = screen.getByLabelText(/go to previous page/i);
+    const nextButton = screen.getByLabelText(/go to next page/i);
+
+    expect(prevButton).toContainElement(prevText);
+    expect(nextButton).toContainElement(nextText);
   });
 });

--- a/src/component-catalog/Pagination/Pagination.test.tsx
+++ b/src/component-catalog/Pagination/Pagination.test.tsx
@@ -101,7 +101,12 @@ describe('Pagination Component', () => {
     fireEvent.click(option20);
 
     expect(handleRowsPerPageChange).toHaveBeenCalledTimes(1);
-    expect(handleRowsPerPageChange).toHaveBeenCalledWith(expect.anything(), expect.anything());
+    expect(handleRowsPerPageChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.objectContaining({ value: 20 }),
+      }),
+      expect.anything()
+    );
   });
 
   it('disables all buttons when disabled prop is true', () => {

--- a/src/component-catalog/Pagination/Pagination.test.tsx
+++ b/src/component-catalog/Pagination/Pagination.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { Pagination } from './Pagination';
+import { PAGINATION_TEST_ID } from './Pagination.constants';
+
+describe('Pagination Component', () => {
+  it('renders the pagination container correctly', () => {
+    render(<Pagination count={5} />);
+    const container = screen.getByTestId(PAGINATION_TEST_ID);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders the correct number of pages', () => {
+    render(<Pagination count={3} />);
+    // Expect pages 1, 2, 3 plus Prev and Next items
+    const items = screen.getAllByRole('button');
+    expect(items).toHaveLength(5);
+  });
+
+  it('triggers onChange event when a page is clicked', () => {
+    const handleChange = vi.fn();
+    render(<Pagination count={3} onChange={handleChange} />);
+
+    const pageTwoButton = screen.getByText('2');
+    pageTwoButton.click();
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders custom previous and next texts', () => {
+    render(<Pagination count={3} />);
+    expect(screen.getByText('Previous')).toBeInTheDocument();
+    expect(screen.getByText('Next')).toBeInTheDocument();
+  });
+});

--- a/src/component-catalog/Pagination/Pagination.tsx
+++ b/src/component-catalog/Pagination/Pagination.tsx
@@ -1,17 +1,77 @@
-import { PrevIcon, NextIcon, PAGINATION_TEST_ID } from './Pagination.constants';
+import { useMediaQuery, useTheme, Select, MenuItem, Typography, Box } from '@mui/material';
+
+import {
+  PrevIcon,
+  NextIcon,
+  PAGINATION_TEST_ID,
+  DEFAULT_PAGE_COUNT,
+  DEFAULT_ROWS_PER_PAGE_OPTIONS,
+} from './Pagination.constants';
 import { PaginationContainer, StyledPagination, StyledPaginationItem } from './Pagination.styles';
 
 import type { PaginationProps } from './Pagination.types';
 
 const Pagination = (props: PaginationProps) => {
-  const { count = 3, page, onChange, ...rest } = props;
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
+  const {
+    count = DEFAULT_PAGE_COUNT,
+    page,
+    onChange,
+    dataTestId = PAGINATION_TEST_ID,
+    showFirstButton = false,
+    showLastButton = false,
+    siblingCount = isMobile ? 0 : 1,
+    boundaryCount = 1,
+    disabled = false,
+    size = 'medium',
+    color = 'standard',
+    variant = 'text',
+    shape = 'circular',
+    rowsPerPage,
+    rowsPerPageOptions = DEFAULT_ROWS_PER_PAGE_OPTIONS,
+    onRowsPerPageChange,
+    ...rest
+  } = props;
 
   return (
-    <PaginationContainer data-testid={PAGINATION_TEST_ID}>
+    <PaginationContainer data-testid={dataTestId}>
+      {}
+      {onRowsPerPageChange && rowsPerPage !== undefined && (
+        <Box display="flex" alignItems="center" gap={1} mr={3}>
+          <Typography variant="body2" color="text.secondary">
+            Rows per page:
+          </Typography>
+          <Select
+            value={rowsPerPage}
+            onChange={onRowsPerPageChange}
+            size="small"
+            disabled={disabled}
+            sx={{ minWidth: '70px', height: '32px', borderRadius: 2 }}
+          >
+            {rowsPerPageOptions.map((option) => (
+              <MenuItem key={option} value={option}>
+                {option}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+      )}
+
       <StyledPagination
         count={count}
         page={page}
         onChange={onChange}
+        showFirstButton={showFirstButton}
+        showLastButton={showLastButton}
+        siblingCount={siblingCount}
+        boundaryCount={boundaryCount}
+        disabled={disabled}
+        size={size}
+        color={color}
+        variant={variant}
+        shape={shape}
         renderItem={(item) => (
           <StyledPaginationItem
             {...item}
@@ -27,4 +87,4 @@ const Pagination = (props: PaginationProps) => {
   );
 };
 
-export { Pagination };
+export default Pagination;

--- a/src/component-catalog/Pagination/Pagination.tsx
+++ b/src/component-catalog/Pagination/Pagination.tsx
@@ -1,0 +1,30 @@
+import { PrevIcon, NextIcon, PAGINATION_TEST_ID } from './Pagination.constants';
+import { PaginationContainer, StyledPagination, StyledPaginationItem } from './Pagination.styles';
+
+import type { PaginationProps } from './Pagination.types';
+
+const Pagination = (props: PaginationProps) => {
+  const { count = 3, page, onChange, ...rest } = props;
+
+  return (
+    <PaginationContainer data-testid={PAGINATION_TEST_ID}>
+      <StyledPagination
+        count={count}
+        page={page}
+        onChange={onChange}
+        renderItem={(item) => (
+          <StyledPaginationItem
+            {...item}
+            slots={{
+              previous: PrevIcon,
+              next: NextIcon,
+            }}
+          />
+        )}
+        {...rest}
+      />
+    </PaginationContainer>
+  );
+};
+
+export { Pagination };

--- a/src/component-catalog/Pagination/Pagination.tsx
+++ b/src/component-catalog/Pagination/Pagination.tsx
@@ -1,5 +1,4 @@
 import { useMediaQuery, useTheme, Select, MenuItem, Typography, Box } from '@mui/material';
-import type { SelectChangeEvent } from '@mui/material';
 
 import {
   PrevIcon,
@@ -11,6 +10,7 @@ import {
 import { PaginationContainer, StyledPagination, StyledPaginationItem } from './Pagination.styles';
 
 import type { PaginationProps } from './Pagination.types';
+import type { SelectChangeEvent } from '@mui/material';
 
 const Pagination = (props: PaginationProps) => {
   const theme = useTheme();
@@ -38,6 +38,7 @@ const Pagination = (props: PaginationProps) => {
 
   const handleRowsPerPageChange = (event: SelectChangeEvent<number>) => {
     if (rowsPerPage !== undefined && onRowsPerPageChange) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       onRowsPerPageChange(event as any);
     }
   };

--- a/src/component-catalog/Pagination/Pagination.tsx
+++ b/src/component-catalog/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import { useMediaQuery, useTheme, Select, MenuItem, Typography, Box } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material';
 
 import {
   PrevIcon,
@@ -22,7 +23,7 @@ const Pagination = (props: PaginationProps) => {
     dataTestId = PAGINATION_TEST_ID,
     showFirstButton = false,
     showLastButton = false,
-    siblingCount = isMobile ? 1 : 1,
+    siblingCount = isMobile ? 0 : 1,
     boundaryCount = 1,
     disabled = false,
     size = 'medium',
@@ -35,6 +36,12 @@ const Pagination = (props: PaginationProps) => {
     ...rest
   } = props;
 
+  const handleRowsPerPageChange = (event: SelectChangeEvent<number>) => {
+    if (rowsPerPage !== undefined && onRowsPerPageChange) {
+      onRowsPerPageChange(event as any);
+    }
+  };
+
   return (
     <PaginationContainer data-testid={dataTestId}>
       {onRowsPerPageChange && rowsPerPage !== undefined && (
@@ -44,7 +51,7 @@ const Pagination = (props: PaginationProps) => {
           </Typography>
           <Select
             value={rowsPerPage}
-            onChange={onRowsPerPageChange}
+            onChange={handleRowsPerPageChange}
             size="small"
             disabled={disabled}
             sx={{

--- a/src/component-catalog/Pagination/Pagination.tsx
+++ b/src/component-catalog/Pagination/Pagination.tsx
@@ -22,11 +22,11 @@ const Pagination = (props: PaginationProps) => {
     dataTestId = PAGINATION_TEST_ID,
     showFirstButton = false,
     showLastButton = false,
-    siblingCount = isMobile ? 0 : 1,
+    siblingCount = isMobile ? 1 : 1,
     boundaryCount = 1,
     disabled = false,
     size = 'medium',
-    color = 'standard',
+    color,
     variant = 'text',
     shape = 'circular',
     rowsPerPage,
@@ -37,7 +37,6 @@ const Pagination = (props: PaginationProps) => {
 
   return (
     <PaginationContainer data-testid={dataTestId}>
-      {}
       {onRowsPerPageChange && rowsPerPage !== undefined && (
         <Box display="flex" alignItems="center" gap={1} mr={3}>
           <Typography variant="body2" color="text.secondary">
@@ -48,7 +47,11 @@ const Pagination = (props: PaginationProps) => {
             onChange={onRowsPerPageChange}
             size="small"
             disabled={disabled}
-            sx={{ minWidth: '70px', height: '32px', borderRadius: 2 }}
+            sx={{
+              minWidth: theme.spacing(8.75),
+              height: theme.spacing(4),
+              borderRadius: 1,
+            }}
           >
             {rowsPerPageOptions.map((option) => (
               <MenuItem key={option} value={option}>

--- a/src/component-catalog/Pagination/Pagination.types.ts
+++ b/src/component-catalog/Pagination/Pagination.types.ts
@@ -1,10 +1,36 @@
 import type { PaginationProps as MuiPaginationProps } from '@mui/material';
+import type { SelectChangeEvent } from '@mui/material/Select';
 
-export interface PaginationProps
-  extends Omit<MuiPaginationProps, 'variant' | 'shape' | 'renderItem'> {
-  count?: number;
+/**
+ * Props for the Pagination component.
+ *
+ * It inherits all standard Material UI Pagination props (e.g., count, page, onChange,
+ * showFirstButton, siblingCount, size, variant, shape, etc.) to ensure full compatibility.
+ *
+ * @note `renderItem` is deliberately omitted because the component internally controls
+ * the item rendering to enforce custom design system SVG iconography and mobile a11y behaviors.
+ */
+export interface PaginationProps extends Omit<MuiPaginationProps, 'renderItem'> {
+  /**
+   * Optional custom test ID for testing environments.
+   * @default 'pagination-component'
+   */
+  dataTestId?: string;
 
-  page?: number;
+  /**
+   * Current number of rows per page.
+   * Passing this prop along with `onRowsPerPageChange` enables the row selector.
+   */
+  rowsPerPage?: number;
 
-  onChange?: (event: React.ChangeEvent<unknown>, page: number) => void;
+  /**
+   * Available options for the rows per page selector dropdown.
+   * @default [10, 20, 50]
+   */
+  rowsPerPageOptions?: number[];
+
+  /**
+   * Callback fired when the user selects a new rows per page value.
+   */
+  onRowsPerPageChange?: (event: SelectChangeEvent<number>) => void;
 }

--- a/src/component-catalog/Pagination/Pagination.types.ts
+++ b/src/component-catalog/Pagination/Pagination.types.ts
@@ -1,0 +1,10 @@
+import type { PaginationProps as MuiPaginationProps } from '@mui/material';
+
+export interface PaginationProps
+  extends Omit<MuiPaginationProps, 'variant' | 'shape' | 'renderItem'> {
+  count?: number;
+
+  page?: number;
+
+  onChange?: (event: React.ChangeEvent<unknown>, page: number) => void;
+}


### PR DESCRIPTION
This PR introduces the new `Pagination` component, strictly following the Figma design specifications and the Component-Driven architecture guidelines. 
Responsive Behavior
- Desktop: Full pagination view with previous/next labels and numeric indicators.
- Mobile :Gracefully collapses text labels, rendering `36x36px` square icon buttons to prevent layout overflow and maintain touch-target accessibility.
URI: https://ditmar.github.io/leetcode-spa/feature-leetcode-198
<img width="1050" height="130" alt="image" src="https://github.com/user-attachments/assets/edd2ca50-ee29-4961-b690-c23dd11f62c2" />
<img width="1051" height="117" alt="image" src="https://github.com/user-attachments/assets/9c59acde-637f-43b7-95b0-a3c11bcc39f4" />
<img width="1045" height="108" alt="image" src="https://github.com/user-attachments/assets/4c9dcc7e-d118-4a8d-a1a2-0bd4e6d99a77" />
