### PR TITLE
feat: implement contestsService for SSR and client-side contest interactions

### DIFF
--- a/src/services/contests/contestsService.test.ts
+++ b/src/services/contests/contestsService.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from '../api/apiClient';
+
+import { contestsService } from './contestsService';
+
+vi.mock('../api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPost = vi.mocked(apiClient.post);
+const mockedDelete = vi.mocked(apiClient.delete);
+
+describe('contestsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns contests without filters by default', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 1,
+          title: 'Weekly Contest 1',
+          status: 'active',
+          startTime: '2026-05-10T10:00:00.000Z',
+          endTime: '2026-05-10T12:00:00.000Z',
+        },
+      ],
+      meta: {
+        totalCount: 1,
+        currentPage: 1,
+        pageCount: 1,
+        perPage: 10,
+      },
+    });
+
+    const result = await contestsService.getContests();
+
+    expect(mockedGet).toHaveBeenCalledWith('/contests', undefined);
+    expect(result).toEqual({
+      contests: [
+        {
+          id: 1,
+          title: 'Weekly Contest 1',
+          status: 'active',
+          startTime: '2026-05-10T10:00:00.000Z',
+          endTime: '2026-05-10T12:00:00.000Z',
+        },
+      ],
+      meta: {
+        totalCount: 1,
+        currentPage: 1,
+        pageCount: 1,
+        perPage: 10,
+      },
+    });
+  });
+
+  it('returns contests using filters and forwards cookie in SSR requests', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        contests: [
+          {
+            id: 2,
+            title: 'Weekly Contest 2',
+            status: 'active',
+            startTime: '2026-05-11T10:00:00.000Z',
+            endTime: '2026-05-11T12:00:00.000Z',
+          },
+        ],
+      },
+    });
+
+    await contestsService.getContests(
+      {
+        status: 'active',
+        page: 2,
+        pageSize: 5,
+      },
+      {
+        cookie: 'auth_token=test-token',
+      }
+    );
+
+    expect(mockedGet).toHaveBeenCalledWith('/contests?status=active&page=2&pageSize=5', {
+      headers: {
+        Cookie: 'auth_token=test-token',
+      },
+    });
+  });
+
+  it('returns contest detail and forwards cookie in SSR requests', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        id: 7,
+        title: 'Weekly Contest 7',
+        status: 'upcoming',
+        startTime: '2026-05-20T10:00:00.000Z',
+        endTime: '2026-05-20T12:00:00.000Z',
+        isRegistered: true,
+        problems: [],
+      },
+    });
+
+    const result = await contestsService.getContestById(7, {
+      cookie: 'auth_token=test-token',
+    });
+
+    expect(mockedGet).toHaveBeenCalledWith('/contests/7', {
+      headers: {
+        Cookie: 'auth_token=test-token',
+      },
+    });
+    expect(result.isRegistered).toBe(true);
+  });
+
+  it('throws when getContestById fails', async () => {
+    const apiError = {
+      status: 404,
+      code: 'NOT_FOUND',
+      message: 'Contest not found',
+    };
+
+    mockedGet.mockRejectedValueOnce(apiError);
+
+    await expect(contestsService.getContestById(999)).rejects.toEqual(apiError);
+    expect(mockedGet).toHaveBeenCalledWith('/contests/999', undefined);
+  });
+
+  it('joins a contest successfully', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        id: 10,
+        title: 'Weekly Contest 10',
+        status: 'upcoming',
+        startTime: '2026-05-25T10:00:00.000Z',
+        endTime: '2026-05-25T12:00:00.000Z',
+        problems: [],
+      },
+    });
+
+    mockedPost.mockResolvedValueOnce({
+      data: null,
+    });
+
+    await expect(contestsService.joinContest(10)).resolves.toBeUndefined();
+    expect(mockedGet).toHaveBeenCalledWith('/contests/10', undefined);
+    expect(mockedPost).toHaveBeenCalledWith('/contests/10/register', null);
+  });
+
+  it('throws when contest is closed in joinContest', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        id: 11,
+        title: 'Weekly Contest 11',
+        status: 'active',
+        startTime: '2026-05-10T10:00:00.000Z',
+        endTime: '2026-05-10T12:00:00.000Z',
+        problems: [],
+      },
+    });
+
+    await expect(contestsService.joinContest(11)).rejects.toEqual({
+      status: 409,
+      code: 'CONTEST_CLOSED',
+      message: 'Contest is not open for registration',
+    });
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('throws when user is already registered in joinContest', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        id: 10,
+        title: 'Weekly Contest 10',
+        status: 'upcoming',
+        startTime: '2026-05-25T10:00:00.000Z',
+        endTime: '2026-05-25T12:00:00.000Z',
+        problems: [],
+      },
+    });
+
+    const apiError = {
+      status: 409,
+      code: 'ALREADY_REGISTERED',
+      message: 'User already registered',
+    };
+
+    mockedPost.mockRejectedValueOnce(apiError);
+
+    await expect(contestsService.joinContest(10)).rejects.toEqual(apiError);
+    expect(mockedPost).toHaveBeenCalledWith('/contests/10/register', null);
+  });
+
+  it('returns leaderboard entries with pagination metadata', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: [
+        {
+          rank: 1,
+          userId: 'user-1',
+          username: 'alice',
+          avatarUrl: 'https://example.com/avatar.png',
+          score: 400,
+          finishTime: '2026-05-10T11:30:00.000Z',
+        },
+      ],
+      meta: {
+        totalCount: 20,
+        currentPage: 2,
+        pageCount: 4,
+        perPage: 5,
+      },
+    });
+
+    const result = await contestsService.getLeaderboard(5, 2);
+
+    expect(mockedGet).toHaveBeenCalledWith('/contests/5/leaderboard?page=2', undefined);
+    expect(result).toEqual({
+      entries: [
+        {
+          rank: 1,
+          userId: 'user-1',
+          username: 'alice',
+          avatarUrl: 'https://example.com/avatar.png',
+          score: 400,
+          finishTime: '2026-05-10T11:30:00.000Z',
+        },
+      ],
+      meta: {
+        totalCount: 20,
+        currentPage: 2,
+        pageCount: 4,
+        perPage: 5,
+      },
+    });
+  });
+
+  it('leaves a contest successfully', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        id: 15,
+        title: 'Weekly Contest 15',
+        status: 'upcoming',
+        startTime: '2026-05-30T10:00:00.000Z',
+        endTime: '2026-05-30T12:00:00.000Z',
+        problems: [],
+      },
+    });
+
+    mockedDelete.mockResolvedValueOnce({
+      data: null,
+    });
+
+    await expect(contestsService.leaveContest(15)).resolves.toBeUndefined();
+    expect(mockedGet).toHaveBeenCalledWith('/contests/15', undefined);
+    expect(mockedDelete).toHaveBeenCalledWith('/contests/15/register');
+  });
+
+  it('throws early when leaveContest is called for a non-upcoming contest', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        id: 16,
+        title: 'Weekly Contest 16',
+        status: 'active',
+        startTime: '2026-05-10T10:00:00.000Z',
+        endTime: '2026-05-10T12:00:00.000Z',
+        problems: [],
+      },
+    });
+
+    await expect(contestsService.leaveContest(16)).rejects.toEqual({
+      status: 409,
+      code: 'CONTEST_NOT_UPCOMING',
+      message: 'Contest registration can only be cancelled for upcoming contests',
+    });
+    expect(mockedDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/contests/contestsService.test.ts
+++ b/src/services/contests/contestsService.test.ts
@@ -81,6 +81,15 @@ function createLeaderboardEntry(overrides: Partial<LeaderboardEntry> = {}): Lead
   };
 }
 
+function parseRequestPath(path: string): { pathname: string; params: URLSearchParams } {
+  const [pathname, queryString = ''] = path.split('?');
+
+  return {
+    pathname,
+    params: new URLSearchParams(queryString),
+  };
+}
+
 describe('contestsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,6 +108,7 @@ describe('contestsService', () => {
       createApiResponse<ContestListResponse>(
         {
           contests,
+          meta: defaultMeta,
         },
         defaultMeta
       )
@@ -127,6 +137,7 @@ describe('contestsService', () => {
     mockedGet.mockResolvedValueOnce(
       createApiResponse<ContestListResponse>({
         contests,
+        meta: defaultMeta,
       })
     );
 
@@ -141,7 +152,17 @@ describe('contestsService', () => {
       }
     );
 
-    expect(mockedGet).toHaveBeenCalledWith('/contests?status=active&page=2&pageSize=5', {
+    const [requestPath, requestConfig] = mockedGet.mock.calls[0] as [
+      string,
+      { headers: { Cookie: string } } | undefined,
+    ];
+    const { pathname, params } = parseRequestPath(requestPath);
+
+    expect(pathname).toBe('/contests');
+    expect(params.get('status')).toBe('active');
+    expect(params.get('page')).toBe('2');
+    expect(params.get('pageSize')).toBe('5');
+    expect(requestConfig).toEqual({
       headers: {
         Cookie: 'auth_token=test-token',
       },
@@ -268,6 +289,12 @@ describe('contestsService', () => {
       createApiResponse<LeaderboardResponse>(
         {
           entries,
+          meta: {
+            totalCount: 20,
+            currentPage: 2,
+            pageCount: 4,
+            perPage: 5,
+          },
         },
         {
           totalCount: 20,
@@ -280,7 +307,11 @@ describe('contestsService', () => {
 
     const result = await contestsService.getLeaderboard(5, 2);
 
-    expect(mockedGet).toHaveBeenCalledWith('/contests/5/leaderboard?page=2', undefined);
+    const [requestPath] = mockedGet.mock.calls[0] as [string, unknown];
+    const { pathname, params } = parseRequestPath(requestPath);
+
+    expect(pathname).toBe('/contests/5/leaderboard');
+    expect(params.get('page')).toBe('2');
     expect(result).toEqual({
       entries,
       meta: {

--- a/src/services/contests/contestsService.test.ts
+++ b/src/services/contests/contestsService.test.ts
@@ -4,6 +4,15 @@ import { apiClient } from '../api/apiClient';
 
 import { contestsService } from './contestsService';
 
+import type {
+  Contest,
+  ContestDetail,
+  ContestListResponse,
+  LeaderboardEntry,
+  LeaderboardResponse,
+} from './contestsService.types';
+import type { ApiError, ApiResponse } from '../api/apiClient';
+
 vi.mock('../api/apiClient', () => ({
   apiClient: {
     get: vi.fn(),
@@ -16,66 +25,110 @@ const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);
 const mockedDelete = vi.mocked(apiClient.delete);
 
+const defaultMeta = {
+  totalCount: 1,
+  currentPage: 1,
+  pageCount: 1,
+  perPage: 10,
+};
+
+function createApiResponse<T>(data: T, meta?: ApiResponse<T>['meta']): ApiResponse<T> {
+  return {
+    data,
+    ...(meta ? { meta } : {}),
+  };
+}
+
+function createApiError(overrides: Partial<ApiError> = {}): ApiError {
+  return {
+    status: 500,
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'Unexpected server error',
+    ...overrides,
+  };
+}
+
+function createContest(overrides: Partial<Contest> = {}): Contest {
+  return {
+    id: 1,
+    title: 'Weekly Contest 1',
+    description: 'Contest description',
+    status: 'upcoming',
+    startTime: '2026-05-10T10:00:00.000Z',
+    endTime: '2026-05-10T12:00:00.000Z',
+    participantsCount: 0,
+    ...overrides,
+  };
+}
+
+function createContestDetail(overrides: Partial<ContestDetail> = {}): ContestDetail {
+  return {
+    ...createContest(),
+    problems: [],
+    ...overrides,
+  };
+}
+
+function createLeaderboardEntry(overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry {
+  return {
+    rank: 1,
+    userId: 'user-1',
+    username: 'alice',
+    avatarUrl: 'https://example.com/avatar.png',
+    score: 400,
+    finishTime: '2026-05-10T11:30:00.000Z',
+    ...overrides,
+  };
+}
+
 describe('contestsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('returns contests without filters by default', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: [
+    const contests = [
+      createContest({
+        id: 1,
+        title: 'Weekly Contest 1',
+        status: 'active',
+      }),
+    ];
+
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestListResponse>(
         {
-          id: 1,
-          title: 'Weekly Contest 1',
-          status: 'active',
-          startTime: '2026-05-10T10:00:00.000Z',
-          endTime: '2026-05-10T12:00:00.000Z',
+          contests,
         },
-      ],
-      meta: {
-        totalCount: 1,
-        currentPage: 1,
-        pageCount: 1,
-        perPage: 10,
-      },
-    });
+        defaultMeta
+      )
+    );
 
     const result = await contestsService.getContests();
 
     expect(mockedGet).toHaveBeenCalledWith('/contests', undefined);
     expect(result).toEqual({
-      contests: [
-        {
-          id: 1,
-          title: 'Weekly Contest 1',
-          status: 'active',
-          startTime: '2026-05-10T10:00:00.000Z',
-          endTime: '2026-05-10T12:00:00.000Z',
-        },
-      ],
-      meta: {
-        totalCount: 1,
-        currentPage: 1,
-        pageCount: 1,
-        perPage: 10,
-      },
+      contests,
+      meta: defaultMeta,
     });
   });
 
   it('returns contests using filters and forwards cookie in SSR requests', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        contests: [
-          {
-            id: 2,
-            title: 'Weekly Contest 2',
-            status: 'active',
-            startTime: '2026-05-11T10:00:00.000Z',
-            endTime: '2026-05-11T12:00:00.000Z',
-          },
-        ],
-      },
-    });
+    const contests = [
+      createContest({
+        id: 2,
+        title: 'Weekly Contest 2',
+        status: 'active',
+        startTime: '2026-05-11T10:00:00.000Z',
+        endTime: '2026-05-11T12:00:00.000Z',
+      }),
+    ];
+
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestListResponse>({
+        contests,
+      })
+    );
 
     await contestsService.getContests(
       {
@@ -96,17 +149,15 @@ describe('contestsService', () => {
   });
 
   it('returns contest detail and forwards cookie in SSR requests', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        id: 7,
-        title: 'Weekly Contest 7',
-        status: 'upcoming',
-        startTime: '2026-05-20T10:00:00.000Z',
-        endTime: '2026-05-20T12:00:00.000Z',
-        isRegistered: true,
-        problems: [],
-      },
-    });
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 7,
+          title: 'Weekly Contest 7',
+          isRegistered: true,
+        })
+      )
+    );
 
     const result = await contestsService.getContestById(7, {
       cookie: 'auth_token=test-token',
@@ -121,11 +172,11 @@ describe('contestsService', () => {
   });
 
   it('throws when getContestById fails', async () => {
-    const apiError = {
+    const apiError = createApiError({
       status: 404,
       code: 'NOT_FOUND',
       message: 'Contest not found',
-    };
+    });
 
     mockedGet.mockRejectedValueOnce(apiError);
 
@@ -134,37 +185,48 @@ describe('contestsService', () => {
   });
 
   it('joins a contest successfully', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        id: 10,
-        title: 'Weekly Contest 10',
-        status: 'upcoming',
-        startTime: '2026-05-25T10:00:00.000Z',
-        endTime: '2026-05-25T12:00:00.000Z',
-        problems: [],
-      },
-    });
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 10,
+          title: 'Weekly Contest 10',
+          status: 'upcoming',
+          startTime: '2026-05-25T10:00:00.000Z',
+          endTime: '2026-05-25T12:00:00.000Z',
+        })
+      )
+    );
 
-    mockedPost.mockResolvedValueOnce({
-      data: null,
-    });
+    mockedPost.mockResolvedValueOnce(createApiResponse<null>(null));
 
     await expect(contestsService.joinContest(10)).resolves.toBeUndefined();
     expect(mockedGet).toHaveBeenCalledWith('/contests/10', undefined);
-    expect(mockedPost).toHaveBeenCalledWith('/contests/10/register', null);
+    expect(mockedPost).toHaveBeenCalledWith('/contests/10/register', null, undefined);
+  });
+
+  it('does not attempt registration when contest detail request fails in joinContest', async () => {
+    const apiError = createApiError({
+      status: 404,
+      code: 'NOT_FOUND',
+      message: 'Contest not found',
+    });
+
+    mockedGet.mockRejectedValueOnce(apiError);
+
+    await expect(contestsService.joinContest(10)).rejects.toEqual(apiError);
+    expect(mockedPost).not.toHaveBeenCalled();
   });
 
   it('throws when contest is closed in joinContest', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        id: 11,
-        title: 'Weekly Contest 11',
-        status: 'active',
-        startTime: '2026-05-10T10:00:00.000Z',
-        endTime: '2026-05-10T12:00:00.000Z',
-        problems: [],
-      },
-    });
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 11,
+          title: 'Weekly Contest 11',
+          status: 'active',
+        })
+      )
+    );
 
     await expect(contestsService.joinContest(11)).rejects.toEqual({
       status: 409,
@@ -175,63 +237,52 @@ describe('contestsService', () => {
   });
 
   it('throws when user is already registered in joinContest', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        id: 10,
-        title: 'Weekly Contest 10',
-        status: 'upcoming',
-        startTime: '2026-05-25T10:00:00.000Z',
-        endTime: '2026-05-25T12:00:00.000Z',
-        problems: [],
-      },
-    });
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 10,
+          title: 'Weekly Contest 10',
+          status: 'upcoming',
+          startTime: '2026-05-25T10:00:00.000Z',
+          endTime: '2026-05-25T12:00:00.000Z',
+        })
+      )
+    );
 
-    const apiError = {
+    const apiError = createApiError({
       status: 409,
       code: 'ALREADY_REGISTERED',
       message: 'User already registered',
-    };
+    });
 
     mockedPost.mockRejectedValueOnce(apiError);
 
     await expect(contestsService.joinContest(10)).rejects.toEqual(apiError);
-    expect(mockedPost).toHaveBeenCalledWith('/contests/10/register', null);
+    expect(mockedPost).toHaveBeenCalledWith('/contests/10/register', null, undefined);
   });
 
   it('returns leaderboard entries with pagination metadata', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: [
+    const entries = [createLeaderboardEntry()];
+
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<LeaderboardResponse>(
         {
-          rank: 1,
-          userId: 'user-1',
-          username: 'alice',
-          avatarUrl: 'https://example.com/avatar.png',
-          score: 400,
-          finishTime: '2026-05-10T11:30:00.000Z',
+          entries,
         },
-      ],
-      meta: {
-        totalCount: 20,
-        currentPage: 2,
-        pageCount: 4,
-        perPage: 5,
-      },
-    });
+        {
+          totalCount: 20,
+          currentPage: 2,
+          pageCount: 4,
+          perPage: 5,
+        }
+      )
+    );
 
     const result = await contestsService.getLeaderboard(5, 2);
 
     expect(mockedGet).toHaveBeenCalledWith('/contests/5/leaderboard?page=2', undefined);
     expect(result).toEqual({
-      entries: [
-        {
-          rank: 1,
-          userId: 'user-1',
-          username: 'alice',
-          avatarUrl: 'https://example.com/avatar.png',
-          score: 400,
-          finishTime: '2026-05-10T11:30:00.000Z',
-        },
-      ],
+      entries,
       meta: {
         totalCount: 20,
         currentPage: 2,
@@ -242,37 +293,58 @@ describe('contestsService', () => {
   });
 
   it('leaves a contest successfully', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        id: 15,
-        title: 'Weekly Contest 15',
-        status: 'upcoming',
-        startTime: '2026-05-30T10:00:00.000Z',
-        endTime: '2026-05-30T12:00:00.000Z',
-        problems: [],
-      },
-    });
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 15,
+          title: 'Weekly Contest 15',
+          status: 'upcoming',
+          startTime: '2026-05-30T10:00:00.000Z',
+          endTime: '2026-05-30T12:00:00.000Z',
+        })
+      )
+    );
 
-    mockedDelete.mockResolvedValueOnce({
-      data: null,
-    });
+    mockedDelete.mockResolvedValueOnce(createApiResponse<null>(null));
 
     await expect(contestsService.leaveContest(15)).resolves.toBeUndefined();
     expect(mockedGet).toHaveBeenCalledWith('/contests/15', undefined);
-    expect(mockedDelete).toHaveBeenCalledWith('/contests/15/register');
+    expect(mockedDelete).toHaveBeenCalledWith('/contests/15/register', undefined);
+  });
+
+  it('propagates delete API errors in leaveContest', async () => {
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 15,
+          title: 'Weekly Contest 15',
+          status: 'upcoming',
+        })
+      )
+    );
+
+    const apiError = createApiError({
+      status: 500,
+      code: 'DELETE_FAILED',
+      message: 'Failed to cancel registration',
+    });
+
+    mockedDelete.mockRejectedValueOnce(apiError);
+
+    await expect(contestsService.leaveContest(15)).rejects.toEqual(apiError);
+    expect(mockedDelete).toHaveBeenCalledWith('/contests/15/register', undefined);
   });
 
   it('throws early when leaveContest is called for a non-upcoming contest', async () => {
-    mockedGet.mockResolvedValueOnce({
-      data: {
-        id: 16,
-        title: 'Weekly Contest 16',
-        status: 'active',
-        startTime: '2026-05-10T10:00:00.000Z',
-        endTime: '2026-05-10T12:00:00.000Z',
-        problems: [],
-      },
-    });
+    mockedGet.mockResolvedValueOnce(
+      createApiResponse<ContestDetail>(
+        createContestDetail({
+          id: 16,
+          title: 'Weekly Contest 16',
+          status: 'active',
+        })
+      )
+    );
 
     await expect(contestsService.leaveContest(16)).rejects.toEqual({
       status: 409,

--- a/src/services/contests/contestsService.ts
+++ b/src/services/contests/contestsService.ts
@@ -37,11 +37,17 @@ function buildRequestConfig(options?: ContestRequestOptions): RequestConfig | un
   };
 }
 
-function createApiError(status: number, code: string, message: string): ApiError {
+function createApiError(
+  status: number,
+  code: string,
+  message: string,
+  details?: unknown
+): ApiError {
   return {
     status,
     code,
     message,
+    ...(details !== undefined ? { details } : {}),
   };
 }
 
@@ -60,7 +66,12 @@ function normalizeContestStatusCheckError(error: unknown): ApiError {
     return error;
   }
 
-  return createApiError(500, 'CONTEST_STATUS_CHECK_FAILED', 'Failed to validate contest status');
+  return createApiError(
+    500,
+    'CONTEST_STATUS_CHECK_FAILED',
+    'Failed to validate contest status',
+    error
+  );
 }
 
 function normalizeContestListResponse(

--- a/src/services/contests/contestsService.ts
+++ b/src/services/contests/contestsService.ts
@@ -1,0 +1,166 @@
+import { apiClient } from '../api/apiClient';
+
+import type {
+  Contest,
+  ContestDetail,
+  ContestFilters,
+  ContestListResponse,
+  ContestRequestOptions,
+  LeaderboardEntry,
+  LeaderboardResponse,
+} from './contestsService.types';
+import type { ApiError, RequestConfig } from '../api/apiClient';
+
+function buildQueryString(filters?: ContestFilters): string {
+  if (!filters) {
+    return '';
+  }
+
+  const params = new URLSearchParams();
+
+  if (filters.status) {
+    params.set('status', filters.status);
+  }
+
+  if (filters.page !== undefined) {
+    params.set('page', String(filters.page));
+  }
+
+  if (filters.pageSize !== undefined) {
+    params.set('pageSize', String(filters.pageSize));
+  }
+
+  const query = params.toString();
+
+  return query ? `?${query}` : '';
+}
+
+function buildRequestConfig(options?: ContestRequestOptions): RequestConfig | undefined {
+  if (!options?.cookie) {
+    return undefined;
+  }
+
+  return {
+    headers: {
+      Cookie: options.cookie,
+    },
+  };
+}
+
+function createApiError(status: number, code: string, message: string): ApiError {
+  return {
+    status,
+    code,
+    message,
+  };
+}
+
+async function fetchContestById(
+  id: number,
+  options?: ContestRequestOptions
+): Promise<ContestDetail> {
+  const response = await apiClient.get<ContestDetail>(
+    `/contests/${id}`,
+    buildRequestConfig(options)
+  );
+
+  return response.data;
+}
+
+async function ensureUpcomingContest(contestId: number, error: ApiError): Promise<ContestDetail> {
+  const contest = await fetchContestById(contestId);
+
+  if (contest.status !== 'upcoming') {
+    throw error;
+  }
+
+  return contest;
+}
+
+function normalizeContestListResponse(
+  data: ContestListResponse | Contest[],
+  meta?: ContestListResponse['meta']
+): ContestListResponse {
+  if (Array.isArray(data)) {
+    return {
+      contests: data,
+      meta,
+    };
+  }
+
+  return {
+    contests: data.contests,
+    meta: data.meta ?? meta,
+  };
+}
+
+function normalizeLeaderboardResponse(
+  data: LeaderboardResponse | LeaderboardEntry[],
+  meta?: LeaderboardResponse['meta']
+): LeaderboardResponse {
+  if (Array.isArray(data)) {
+    return {
+      entries: data,
+      meta,
+    };
+  }
+
+  return {
+    entries: data.entries,
+    meta: data.meta ?? meta,
+  };
+}
+
+export const contestsService = {
+  async getContests(
+    filters?: ContestFilters,
+    options?: ContestRequestOptions
+  ): Promise<ContestListResponse> {
+    const query = buildQueryString(filters);
+    const response = await apiClient.get<ContestListResponse | Contest[]>(
+      `/contests${query}`,
+      buildRequestConfig(options)
+    );
+
+    return normalizeContestListResponse(response.data, response.meta);
+  },
+
+  async getContestById(id: number, options?: ContestRequestOptions): Promise<ContestDetail> {
+    return fetchContestById(id, options);
+  },
+
+  async getLeaderboard(
+    contestId: number,
+    page = 1,
+    options?: ContestRequestOptions
+  ): Promise<LeaderboardResponse> {
+    const response = await apiClient.get<LeaderboardResponse | LeaderboardEntry[]>(
+      `/contests/${contestId}/leaderboard?page=${page}`,
+      buildRequestConfig(options)
+    );
+
+    return normalizeLeaderboardResponse(response.data, response.meta);
+  },
+
+  async joinContest(contestId: number): Promise<void> {
+    await ensureUpcomingContest(
+      contestId,
+      createApiError(409, 'CONTEST_CLOSED', 'Contest is not open for registration')
+    );
+
+    await apiClient.post<null>(`/contests/${contestId}/register`, null);
+  },
+
+  async leaveContest(contestId: number): Promise<void> {
+    await ensureUpcomingContest(
+      contestId,
+      createApiError(
+        409,
+        'CONTEST_NOT_UPCOMING',
+        'Contest registration can only be cancelled for upcoming contests'
+      )
+    );
+
+    await apiClient.delete<null>(`/contests/${contestId}/register`);
+  },
+};

--- a/src/services/contests/contestsService.ts
+++ b/src/services/contests/contestsService.ts
@@ -45,6 +45,24 @@ function createApiError(status: number, code: string, message: string): ApiError
   };
 }
 
+function isContestServiceApiError(error: unknown): error is ApiError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'status' in error &&
+    'code' in error &&
+    'message' in error
+  );
+}
+
+function normalizeContestStatusCheckError(error: unknown): ApiError {
+  if (isContestServiceApiError(error)) {
+    return error;
+  }
+
+  return createApiError(500, 'CONTEST_STATUS_CHECK_FAILED', 'Failed to validate contest status');
+}
+
 function normalizeContestListResponse(
   response: ApiResponse<ContestListResponse>
 ): ContestListResponse {
@@ -80,13 +98,17 @@ async function ensureUpcomingContest(
   error: ApiError,
   options?: ContestRequestOptions
 ): Promise<ContestDetail> {
-  const contest = await fetchContestById(contestId, options);
+  try {
+    const contest = await fetchContestById(contestId, options);
 
-  if (contest.status !== 'upcoming') {
-    throw error;
+    if (contest.status !== 'upcoming') {
+      throw error;
+    }
+
+    return contest;
+  } catch (caughtError) {
+    throw normalizeContestStatusCheckError(caughtError);
   }
-
-  return contest;
 }
 
 export const contestsService = {

--- a/src/services/contests/contestsService.ts
+++ b/src/services/contests/contestsService.ts
@@ -1,36 +1,26 @@
 import { apiClient } from '../api/apiClient';
 
 import type {
-  Contest,
   ContestDetail,
   ContestFilters,
   ContestListResponse,
   ContestRequestOptions,
-  LeaderboardEntry,
   LeaderboardResponse,
 } from './contestsService.types';
-import type { ApiError, RequestConfig } from '../api/apiClient';
+import type { ApiError, ApiResponse, RequestConfig } from '../api/apiClient';
 
-function buildQueryString(filters?: ContestFilters): string {
-  if (!filters) {
-    return '';
-  }
+type QueryParams = Record<string, string | number | undefined>;
 
-  const params = new URLSearchParams();
+function buildQueryString(params: QueryParams): string {
+  const searchParams = new URLSearchParams();
 
-  if (filters.status) {
-    params.set('status', filters.status);
-  }
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      searchParams.set(key, String(value));
+    }
+  });
 
-  if (filters.page !== undefined) {
-    params.set('page', String(filters.page));
-  }
-
-  if (filters.pageSize !== undefined) {
-    params.set('pageSize', String(filters.pageSize));
-  }
-
-  const query = params.toString();
+  const query = searchParams.toString();
 
   return query ? `?${query}` : '';
 }
@@ -55,6 +45,24 @@ function createApiError(status: number, code: string, message: string): ApiError
   };
 }
 
+function normalizeContestListResponse(
+  response: ApiResponse<ContestListResponse>
+): ContestListResponse {
+  return {
+    contests: response.data.contests,
+    meta: response.data.meta ?? response.meta,
+  };
+}
+
+function normalizeLeaderboardResponse(
+  response: ApiResponse<LeaderboardResponse>
+): LeaderboardResponse {
+  return {
+    entries: response.data.entries,
+    meta: response.data.meta ?? response.meta,
+  };
+}
+
 async function fetchContestById(
   id: number,
   options?: ContestRequestOptions
@@ -67,8 +75,12 @@ async function fetchContestById(
   return response.data;
 }
 
-async function ensureUpcomingContest(contestId: number, error: ApiError): Promise<ContestDetail> {
-  const contest = await fetchContestById(contestId);
+async function ensureUpcomingContest(
+  contestId: number,
+  error: ApiError,
+  options?: ContestRequestOptions
+): Promise<ContestDetail> {
+  const contest = await fetchContestById(contestId, options);
 
   if (contest.status !== 'upcoming') {
     throw error;
@@ -77,52 +89,23 @@ async function ensureUpcomingContest(contestId: number, error: ApiError): Promis
   return contest;
 }
 
-function normalizeContestListResponse(
-  data: ContestListResponse | Contest[],
-  meta?: ContestListResponse['meta']
-): ContestListResponse {
-  if (Array.isArray(data)) {
-    return {
-      contests: data,
-      meta,
-    };
-  }
-
-  return {
-    contests: data.contests,
-    meta: data.meta ?? meta,
-  };
-}
-
-function normalizeLeaderboardResponse(
-  data: LeaderboardResponse | LeaderboardEntry[],
-  meta?: LeaderboardResponse['meta']
-): LeaderboardResponse {
-  if (Array.isArray(data)) {
-    return {
-      entries: data,
-      meta,
-    };
-  }
-
-  return {
-    entries: data.entries,
-    meta: data.meta ?? meta,
-  };
-}
-
 export const contestsService = {
   async getContests(
     filters?: ContestFilters,
     options?: ContestRequestOptions
   ): Promise<ContestListResponse> {
-    const query = buildQueryString(filters);
-    const response = await apiClient.get<ContestListResponse | Contest[]>(
+    const query = buildQueryString({
+      status: filters?.status,
+      page: filters?.page,
+      pageSize: filters?.pageSize,
+    });
+
+    const response = await apiClient.get<ContestListResponse>(
       `/contests${query}`,
       buildRequestConfig(options)
     );
 
-    return normalizeContestListResponse(response.data, response.meta);
+    return normalizeContestListResponse(response);
   },
 
   async getContestById(id: number, options?: ContestRequestOptions): Promise<ContestDetail> {
@@ -134,33 +117,41 @@ export const contestsService = {
     page = 1,
     options?: ContestRequestOptions
   ): Promise<LeaderboardResponse> {
-    const response = await apiClient.get<LeaderboardResponse | LeaderboardEntry[]>(
-      `/contests/${contestId}/leaderboard?page=${page}`,
+    const query = buildQueryString({ page });
+
+    const response = await apiClient.get<LeaderboardResponse>(
+      `/contests/${contestId}/leaderboard${query}`,
       buildRequestConfig(options)
     );
 
-    return normalizeLeaderboardResponse(response.data, response.meta);
+    return normalizeLeaderboardResponse(response);
   },
 
-  async joinContest(contestId: number): Promise<void> {
+  async joinContest(contestId: number, options?: ContestRequestOptions): Promise<void> {
     await ensureUpcomingContest(
       contestId,
-      createApiError(409, 'CONTEST_CLOSED', 'Contest is not open for registration')
+      createApiError(409, 'CONTEST_CLOSED', 'Contest is not open for registration'),
+      options
     );
 
-    await apiClient.post<null>(`/contests/${contestId}/register`, null);
+    await apiClient.post<null>(
+      `/contests/${contestId}/register`,
+      null,
+      buildRequestConfig(options)
+    );
   },
 
-  async leaveContest(contestId: number): Promise<void> {
+  async leaveContest(contestId: number, options?: ContestRequestOptions): Promise<void> {
     await ensureUpcomingContest(
       contestId,
       createApiError(
         409,
         'CONTEST_NOT_UPCOMING',
         'Contest registration can only be cancelled for upcoming contests'
-      )
+      ),
+      options
     );
 
-    await apiClient.delete<null>(`/contests/${contestId}/register`);
+    await apiClient.delete<null>(`/contests/${contestId}/register`, buildRequestConfig(options));
   },
 };

--- a/src/services/contests/contestsService.types.ts
+++ b/src/services/contests/contestsService.types.ts
@@ -47,20 +47,20 @@ export interface LeaderboardEntry {
 }
 
 export interface PaginationMeta {
-  totalCount?: number;
-  pageCount?: number;
-  currentPage?: number;
-  perPage?: number;
+  totalCount: number;
+  pageCount: number;
+  currentPage: number;
+  perPage: number;
 }
 
 export interface ContestListResponse {
   contests: Contest[];
-  meta?: PaginationMeta;
+  meta: PaginationMeta;
 }
 
 export interface LeaderboardResponse {
   entries: LeaderboardEntry[];
-  meta?: PaginationMeta;
+  meta: PaginationMeta;
 }
 
 export interface ContestRequestOptions {

--- a/src/services/contests/contestsService.types.ts
+++ b/src/services/contests/contestsService.types.ts
@@ -1,6 +1,12 @@
-export type ContestStatus = 'active' | 'upcoming' | 'past';
+export const CONTEST_STATUSES = ['active', 'upcoming', 'past'] as const;
 
-export type Difficulty = 'easy' | 'medium' | 'hard';
+export type ContestStatus = (typeof CONTEST_STATUSES)[number];
+
+export const CONTEST_DIFFICULTIES = ['easy', 'medium', 'hard'] as const;
+
+export type Difficulty = (typeof CONTEST_DIFFICULTIES)[number];
+
+export type IsoDateTimeString = string;
 
 export interface ContestFilters {
   status?: ContestStatus;
@@ -13,8 +19,8 @@ export interface Contest {
   title: string;
   description?: string;
   status: ContestStatus;
-  startTime: string;
-  endTime: string;
+  startTime: IsoDateTimeString;
+  endTime: IsoDateTimeString;
   participantsCount?: number;
 }
 
@@ -37,7 +43,7 @@ export interface LeaderboardEntry {
   username: string;
   avatarUrl?: string;
   score: number;
-  finishTime?: string;
+  finishTime?: IsoDateTimeString;
 }
 
 export interface PaginationMeta {

--- a/src/services/contests/contestsService.types.ts
+++ b/src/services/contests/contestsService.types.ts
@@ -1,0 +1,62 @@
+export type ContestStatus = 'active' | 'upcoming' | 'past';
+
+export type Difficulty = 'easy' | 'medium' | 'hard';
+
+export interface ContestFilters {
+  status?: ContestStatus;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface Contest {
+  id: number;
+  title: string;
+  description?: string;
+  status: ContestStatus;
+  startTime: string;
+  endTime: string;
+  participantsCount?: number;
+}
+
+export interface ContestProblem {
+  id: number;
+  title: string;
+  difficulty: Difficulty;
+  score: number;
+}
+
+export interface ContestDetail extends Contest {
+  problems: ContestProblem[];
+  isRegistered?: boolean;
+  userRank?: number;
+}
+
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  username: string;
+  avatarUrl?: string;
+  score: number;
+  finishTime?: string;
+}
+
+export interface PaginationMeta {
+  totalCount?: number;
+  pageCount?: number;
+  currentPage?: number;
+  perPage?: number;
+}
+
+export interface ContestListResponse {
+  contests: Contest[];
+  meta?: PaginationMeta;
+}
+
+export interface LeaderboardResponse {
+  entries: LeaderboardEntry[];
+  meta?: PaginationMeta;
+}
+
+export interface ContestRequestOptions {
+  cookie?: string;
+}


### PR DESCRIPTION
Closes #244

Implemented the `contestsService` module for SSR and client-side contest interactions.

Changes included:
- added `contestsService.ts` for contest API interactions
- added `contestsService.types.ts` with typed contest, filters, detail, and leaderboard models
- added `contestsService.test.ts` with unit tests for SSR cookie forwarding, contest detail, join, leave, and leaderboard flows
- added support for SSR cookie forwarding in contest requests
- added early validation for contest registration and unregister flows based on contest status
- improved error handling for contest status validation

Validation:
- `corepack yarn vitest run src/services/contests/contestsService.test.ts`
- `corepack yarn lint`

Update:
- addressed the requested review changes
- rebased the branch with `next`
- updated the PR base branch from `master` to `next`
